### PR TITLE
CMakeLists.txt: Fix linking with rt_tests_support

### DIFF
--- a/communication_tests/CMakeLists.txt
+++ b/communication_tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(communication_tests_publisher
    ./src/ArgumentParser.cpp
    ./src/ct_publisher_node.cpp
 )
-target_link_libraries(communication_tests_publisher rt_tests_support ${catkin_LIBRARIES})
+target_link_libraries(communication_tests_publisher ${catkin_LIBRARIES})
 
 add_executable(communication_tests_subscriber
    ./src/Config.cpp
@@ -24,7 +24,7 @@ add_executable(communication_tests_subscriber
    ./src/ArgumentParser.cpp
    ./src/ct_subscriber_node.cpp
 )
-target_link_libraries(communication_tests_subscriber rt_tests_support ${catkin_LIBRARIES})
+target_link_libraries(communication_tests_subscriber ${catkin_LIBRARIES})
 
 install(DIRECTORY launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch

--- a/cyclic_timer_tests/CMakeLists.txt
+++ b/cyclic_timer_tests/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(cyclic_timer_tests
    ./src/ArgumentParser.cpp
    ./src/CyclicLatencyMeasurer.cpp
 )
-target_link_libraries(cyclic_timer_tests rt_tests_support ${catkin_LIBRARIES})
+target_link_libraries(cyclic_timer_tests ${catkin_LIBRARIES})
 
 install(DIRECTORY launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch

--- a/oneshot_timer_tests/CMakeLists.txt
+++ b/oneshot_timer_tests/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(oneshot_timer_tests
    ./src/BusyOneShotLatencyMeasurer.cpp
    ./src/IdleOneShotLatencyMeasurer.cpp
 )
-target_link_libraries(oneshot_timer_tests rt_tests_support ${catkin_LIBRARIES})
+target_link_libraries(oneshot_timer_tests ${catkin_LIBRARIES})
 
 install(DIRECTORY launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch

--- a/rt_tests_support/CMakeLists.txt
+++ b/rt_tests_support/CMakeLists.txt
@@ -3,7 +3,9 @@ project(rt_tests_support)
 
 find_package(catkin REQUIRED COMPONENTS roscpp)
 
-catkin_package()
+catkin_package(DEPENDS roscpp
+	       INCLUDE_DIRS include
+               LIBRARIES ${PROJECT_NAME})
 
 include_directories(${catkin_INCLUDE_DIRS} ./include)
 


### PR DESCRIPTION
The rt_tests_support library should be located and linked as a separate
Catkin module.
